### PR TITLE
Convert to sqlite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ on:
       - main
     paths-ignore:
       - 'README.md'
+  pull_request:
+    branches:
+      - main
 
 defaults:
   run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-containers: [ubuntu, alpine]
+        node-containers: [alpine]
     
     steps:
       - name: Check out the repo

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 .env
 *.log
 logs/
+config/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 This bot will monitor your server and will enforce inactivity based on various rules.
 
+[![Build Status](https://github.com/kmorris896/activity-monitor/actions/workflows/test.yml/badge.svg)](https://github.com/kmorris896/activity-monitor/actions/workflows/test.yml)
+[![Latest Release](https://img.shields.io/github/v/release/kmorris896/activity-monitor?color=%233D9970)](https://img.shields.io/github/v/release/kmorris896/activity-monitor?color=%233D9970)
+
 ## Primary job
 
 Rapture is setup to have an initiation screening prior to entry.  This means users must be approved before they will gain entry to the rest of the server.  When new members enter, a bot gives them a "New Arrival" role.  Once approved, this role is removed.

--- a/commands/channel_activity.js
+++ b/commands/channel_activity.js
@@ -3,7 +3,7 @@ const chatTable = "chatTable_" + process.env.DYNAMODB_TABLE_IDENTIFIER;
 module.exports = {
   name: 'channel_activity',
   description: 'Watch channel activity',
-  execute(msg, logger, docClient) {
+  execute(msg, logger) {
     const messageWordCount = msg.content.trim().split(/\s+/).length;
 
     if (msg.content.startsWith('!') || msg.content.startsWith('.') || msg.author.bot === true) 
@@ -14,21 +14,8 @@ module.exports = {
       return nonbot_messages.first().createdTimestamp;
     }).then(function (lastChannelMessageDatetime) {
       const lastChannelMessageDelta = msg.createdTimestamp - lastChannelMessageDatetime;
+      const userLastMessageDelta = getUserLastMessageDelta(msg, logger);
 
-      let chatItem = {
-        TableName: chatTable,
-        Item: {
-          "serverId": msg.guild.id,
-          "memberId": msg.author.id,
-          "channelId": msg.channel.id,
-          "messageWordCount": messageWordCount,
-          "messageSnowflake": msg.id,
-          "messageLink": msg.url,
-          "messageDateTime": msg.createdTimestamp,
-          "lastChannelMessageDelta": lastChannelMessageDelta
-        }
-      }
-      
       logger.debug(`serverId: ${msg.guild.id}`);
       logger.debug(`memberId: ${msg.author.id}`);
       logger.debug(`channelId: ${msg.channel.id}`);
@@ -38,15 +25,44 @@ module.exports = {
       logger.debug(`messageDateTime: ${msg.createdTimestamp}`);
       logger.debug(`lastChannelMessageDelta: ${lastChannelMessageDelta}`);
 
-      return docClient.put(chatItem, function(err, data) {
-        if (err) {
-          logger.error("Unable to PUT chat item.  Error JSON: " + JSON.stringify(err, null, 2));
-          return true;
-        } else {
-          logger.debug("chatItem putItem succeeded!");
-          return false;
-        }
-      });
+      let chatItem = [
+        msg.guild.id,
+        msg.id,
+        msg.channel.id,
+        lastChannelMessageDelta,
+        msg.author.id,
+        msg.createdTimestamp,
+        msg.url,
+        messageWordCount,
+        userLastMessageDelta
+      ];
+
+      msg.client.db.run(`INSERT INTO chatTable (serverId, messageId, channelId, 
+        lastChannelMessageDelta, memberId, messageDateTime, messageLink, messageWordCount, userLastMessageDelta) 
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`, chatItem, (err) => {
+          if (err) {
+            logger.error(err);
+          } else {
+            logger.info('New message added to chatTable');
+          }
+        });
     });
   }
+}
+
+function getUserLastMessageDelta(msg, logger) {
+  msg.client.db.get(`SELECT messageDateTime FROM chatTable 
+    WHERE serverId = ? AND memberId = ? ORDER BY messageDateTime DESC LIMIT 1;`, [msg.guild.id, msg.author.id], (err, row) => {
+    if (err) {
+      logger.error(err);
+    } else {
+      var userLastMessageDelta = 604800000;
+      if (typeof row !== 'undefined') {
+        userLastMessageDelta = msg.createdTimestamp - row.messageDateTime;
+      }
+
+      logger.debug(`Last message delta for ${msg.author.username} is ${userLastMessageDelta}`);
+      return userLastMessageDelta;
+    }
+  });
 }

--- a/commands/config.js
+++ b/commands/config.js
@@ -1,6 +1,10 @@
 // ---------- DynamoDB Configuration
 const configTable = "configTable_" + process.env.DYNAMODB_TABLE_IDENTIFIER;
 
+// ---------- fs Declarations
+const fs = require("fs");
+
+
 // ---------- DynamoDB Declarations
 var AWS = require("aws-sdk");
 const awsDynamoDbEndpoint = "https://dynamodb." + process.env.AWS_REGION + ".amazonaws.com";
@@ -17,24 +21,11 @@ module.exports = {
     if (args[0] == "hasrole") {
       const hasRole = msg.mentions.roles.first();
 
+      // If there is a role mentioned, store it in the config
       if (typeof hasRole != "undefined") {
-        const configItem = {
-          TableName: "configTable_d8c7c4d5",
-          Item: {
-            "serverId": msg.guild.id,
-            "hasRole": hasRole.id
-          }
-        }
-        
-        docClient.put(configItem, function(err, data) {
-          if (err) {
-            console.error("Unable to PUT item. Error JSON:" + JSON.stringify(err, null, 2));
-          } else {
-            console.debug("putItem succeeded:" + JSON.stringify(data, null, 2));
-            msg.client.botConfig[msg.guild.id].set("hasRole", hasRole.id);
-            return msg.channel.send("Bot will kick users with the role <@&" + hasRole.id + "> within the timeframe.");
-          }
-        });
+        msg.client.botConfig[msg.guild.id].set("hasRole", hasRole.id);
+        msg.channel.send("Bot will kick users with the role <@&" + hasRole.id + "> within the timeframe.");
+        this.saveServerConfig(msg.guild.id, msg.client);
       } else {
         if (msg.client.botConfig[msg.guild.id].has("hasRole")) {
           return msg.channel.send("Bot has been configured to kick users with the role <@&" + msg.client.botConfig[msg.guild.id].get("hasRole") + ">");
@@ -44,24 +35,38 @@ module.exports = {
       }
     }
   },
-  getServerConfig(serverId, client, logger, docClient) {
-    const configParams = {
-      TableName: configTable,
-      Key: {
-        "serverId": serverId.toString()
-      }
-    }
-  
-    docClient.get(configParams, function(err, data) {
-      if (err) {
-        logger.error("Unable to read item.  Error JSON: " + JSON.stringify(err, null, 2));
-      } else {
-        if (data.hasOwnProperty("Item") && data.Item.hasOwnProperty("hasRole")) {
-          logger.debug("getServerConfig hasRole = " + data.Item.hasRole);
-          client.botConfig[serverId].set("hasRole", data.Item.hasRole);
+  initializeConfig(client, logger) {
+    try {
+      const configFile = fs.readFileSync('./config/config.json', 'utf8');
+      configJson = JSON.parse(configFile);
+
+      for (let configServerId in configJson) {
+        if (client.botConfig.hasOwnProperty(configServerId)) {
+          logger.info("Re-loading config for server " + configServerId);
+          client.botConfig[configServerId] = configJson[configServerId];
         } else {
-          logger.debug("getItem returned empty");
-        }  
+          logger.info("Loading config for server " + configServerId);
+          client.botConfig[configServerId] = configJson[configServerId];
+        }
+      }
+    } catch (err) {
+      logger.error("Error loading config file: " + err);
+    }
+  },
+  getServerConfig(serverId, client, logger) {
+      if (configJson.hasOwnProperty(serverId)) {
+        logger.debug("Found config for server " + serverId);
+        client.botConfig[serverId] = configJson[serverId];
+      } else {
+        logger.debug("No config exists for server " + serverId);
+      }
+  },
+  saveServerConfig(client, logger) {
+    fs.writeFile("./config/config.json", JSON.stringify(client.botConfig, null, 2), function(err) {
+      if (err) {
+        logger.error(err);
+      } else {
+        logger.debug("The file was saved!");
       }
     });
   }

--- a/commands/config.js
+++ b/commands/config.js
@@ -1,18 +1,6 @@
-// ---------- DynamoDB Configuration
-const configTable = "configTable_" + process.env.DYNAMODB_TABLE_IDENTIFIER;
-
 // ---------- fs Declarations
 const fs = require("fs");
 
-
-// ---------- DynamoDB Declarations
-var AWS = require("aws-sdk");
-const awsDynamoDbEndpoint = "https://dynamodb." + process.env.AWS_REGION + ".amazonaws.com";
-console.log("Setting endpoint: " + awsDynamoDbEndpoint);
-
-AWS.config.update({endpoint: awsDynamoDbEndpoint, region: process.env.AWS_REGION});
-AWS.config.apiVersions = { dynamodb: '2012-08-10' };
-var docClient = new AWS.DynamoDB.DocumentClient();
 
 module.exports = {
   name: 'config',

--- a/commands/config.js
+++ b/commands/config.js
@@ -23,7 +23,7 @@ module.exports = {
       }
     }
   },
-  initializeConfig(client, logger) {
+  async initializeConfig(client, logger) {
     try {
       const configFile = fs.readFileSync('./config/config.json', 'utf8');
       configJson = JSON.parse(configFile);

--- a/commands/welcome_activity.js
+++ b/commands/welcome_activity.js
@@ -5,34 +5,26 @@ module.exports = {
   name: 'welcome_activity',
   description: 'Welcome Activity Monitor',
 
-  addMember(memberObject, logger, docClient) {
+  addMember(memberObject, logger) {
     // logger.info(JSON.stringify(memberObject));
     logger.info("SERVER JOIN ON " + memberObject.guild.name + " (" + memberObject.guild.id + ")");
     logger.info("memberObject Name: " + memberObject.displayName);
     logger.info("memberObject ID: " + memberObject.id);
     logger.info("Joined at: " + memberObject.joinedTimestamp);
 
-    let memberItem = {
-      TableName: joinTable,
-      Item: {
-        "serverId": memberObject.guild.id,
-        "memberId": memberObject.id,
-        "joinDateTime": memberObject.joinedTimestamp
-      }
-    }
+    // let values =    "'" + memberObject.guild.id + "', '" + memberObject.id + 
+    //              "', '" + memberObject.displayName + "', '" + memberObject.joinedTimestamp + "'";
+    let query = "INSERT INTO joinTable (serverId, memberId, joinDateTime) VALUES (?, ?, ?)";
     
-    logger.info("Adding to DynamoDB...");
-
-    docClient.put(memberItem, function(err, data) {
+    memberObject.client.db.run(query, [memberObject.guild.id, memberId, memberObject.joinedTimestamp], function(err) {
       if (err) {
-        logger.error("Unable to PUT item. Error JSON: " + JSON.stringify(err, null, 2));
-      } else {
-        logger.debug("putItem succeeded: " + JSON.stringify(data, null, 2));
+        return console.error(err.message);
       }
+      console.log(`Row(s) updated: ${this.changes}`);
     });
   },
 
-  checkNewArrivals(guildId, client, logger, docClient) {
+  checkNewArrivals(guildId, client, logger) {
     const oneDay = 1000 * 60 * 60 * 24; // 1 second * 60 = 1 minute * 60 = 1 hour * 24 = 1 day
     const timeHorizon = Date.now() - oneDay;
     
@@ -48,62 +40,49 @@ module.exports = {
         ":datetime": timeHorizon
       } 
     };
-  
-  
-    docClient.query(params, async function(err, data) {
+
+    let query = "SELECT * FROM joinTable WHERE serverId = ? AND joinDateTime < " + timeHorizon;
+    client.db.each(query, [guildId], function(err, member) {
       if (err) {
-        logger.error("Unable to query DynamoDB: " + JSON.stringify(err, null, 2));
-        return 0;
+        return console.error(err.message);
       }
-  
-      logger.debug("Items retrieved: " + data.Items.length);
-      data.Items.forEach(async function (member) {
-        let deleteJoinEntry = false;
-        const dateObject = new Date(member.joinDateTime);
-        logger.debug("memberId " + member.memberId + " joined " + dateObject.toLocaleString());
-  
-        const guildObject = client.guilds.cache.get(member.serverId);
-        if (guildObject.member(member.memberId)) {
-          if (client.botConfig[member.serverId].has("hasRole") &&
-            (guildObject.member(member.memberId).roles.cache.some(role => role.id === client.botConfig[member.serverId].get("hasRole")))) {
-              logger.info("User still exists on server and has the role and has been on the server for the allotted time.");
-              
-              const kickMessage = "Thank you very much for checking us out.  I know life can get busy but since you haven't posted an acceptable intro within 24 hours, I'm giving you a polite nudge.\n\nYou are welcome back anytime by accepting this invite: https://discord.gg/2dXsVsMgUQ";
-              
-              const dmStatus = await client.users.cache.get(member.memberId).send(kickMessage);
-              if (typeof dmStatus.id == "string") {
-                const kickStatus = await guildObject.member(member.memberId).kick("Kicked for failing to create an intro within 24 hours.");
-                deleteJoinEntry = kickStatus.deleted;
-              } 
-          } else {
-            logger.info("User exists but doesn't have the role anymore.  Nothing left to do except delete the entry.");
-            deleteJoinEntry = true;
-          }
+      
+      let deleteJoinEntry = false;
+      const dateObject = new Date(member.joinDateTime);
+      logger.debug("memberId " + member.memberId + " joined " + dateObject.toLocaleString());
+      const guildObject = client.guilds.cache.get(member.serverId);
+      if (guildObject.member(member.memberId)) {
+        if (client.botConfig[member.serverId].has("hasRole") &&
+          (guildObject.member(member.memberId).roles.cache.some(role => role.id === client.botConfig[member.serverId].get("hasRole")))) {
+            logger.info("User still exists on server and has the role and has been on the server for the allotted time.");
+            
+            const kickMessage = "Thank you very much for checking us out.  I know life can get busy but since you haven't posted an acceptable intro within 24 hours, I'm giving you a polite nudge.\n\nYou are welcome back anytime by accepting this invite: https://discord.gg/2dXsVsMgUQ";
+            
+            const dmStatus = await client.users.cache.get(member.memberId).send(kickMessage);
+            if (typeof dmStatus.id == "string") {
+              const kickStatus = await guildObject.member(member.memberId).kick("Kicked for failing to create an intro within 24 hours.");
+              deleteJoinEntry = kickStatus.deleted;
+            } 
         } else {
-          logger.info("User is no longer on the server.");
+          logger.info("User exists but doesn't have the role anymore.  Nothing left to do except delete the entry.");
           deleteJoinEntry = true;
-        }   
-        
-        if (deleteJoinEntry) {
-          const deleteParams = {
-            TableName: joinTable,
-            Key: {
-              "serverId": member.serverId,
-              "memberId": member.memberId
-            }
-          };
-  
-          docClient.delete(deleteParams, function(err, data) {
-            if (err) {
-              logger.error("Unable to DELETE item. Error JSON: " + JSON.stringify(err, null, 2));
-            } else {
-              logger.debug("deleteItem succeeded: " + JSON.stringify(data, null, 2));
-            }
-          });
-        } else {
-          logger.info("User could not be deleted.");
         }
-      });
+      } else {
+        logger.info("User is no longer on the server.");
+        deleteJoinEntry = true;
+      }   
+      
+      if (deleteJoinEntry) {
+        let deleteQuery = "DELETE FROM " + joinTable + " WHERE serverId = ? AND memberId = ?";
+        client.db.run(deleteQuery, [member.serverId, member.memberId], function(err) {
+          if (err) {
+            return console.error(err.message);
+          }
+          console.log(`Row(s) updated: ${this.changes}`);
+        });
+      } else {
+        logger.info("User could not be deleted.");
+      }
     });
   
   }

--- a/commands/welcome_activity.js
+++ b/commands/welcome_activity.js
@@ -1,7 +1,4 @@
-// ---------- DynamoDB Configuration
-const joinTable   = "joinTable_" + process.env.DYNAMODB_TABLE_IDENTIFIER;
-
-module.exports = {
+  module.exports = {
   name: 'welcome_activity',
   description: 'Welcome Activity Monitor',
 
@@ -24,25 +21,15 @@ module.exports = {
     });
   },
 
-  checkNewArrivals(guildId, client, logger) {
+  async checkNewArrivals(guildId, client, logger) {
     const oneDay = 1000 * 60 * 60 * 24; // 1 second * 60 = 1 minute * 60 = 1 hour * 24 = 1 day
     const timeHorizon = Date.now() - oneDay;
     
     logger.info("Looking for entries less than: " + timeHorizon);
     logger.info("On server: " + guildId);
-  
-    let params = {
-      TableName: joinTable,
-      IndexName: "joinTable_joinDateTime",
-      KeyConditionExpression: "serverId = :serverId AND joinDateTime < :datetime",
-      ExpressionAttributeValues: {
-        ":serverId": guildId,
-        ":datetime": timeHorizon
-      } 
-    };
 
     let query = "SELECT * FROM joinTable WHERE serverId = ? AND joinDateTime < " + timeHorizon;
-    client.db.each(query, [guildId], function(err, member) {
+    client.db.each(query, [guildId], async function(err, member) {
       if (err) {
         return console.error(err.message);
       }

--- a/index.js
+++ b/index.js
@@ -10,8 +10,16 @@ const logger = winston.createLogger({
   ]
 });
 
-// ---------- DynamoDB Declarations
-var AWS = require("aws-sdk");
+// ---------- sqlite Declarations
+var AWS = require("sqlite3").verbose();
+let db = new sqlite3.Database(process.env.DBFILE, (err) => {
+  if (err) {
+    console.error(err.message);
+  }
+  console.log('Connected to the database: ' & process.env.DBFILE);
+});
+
+
 logger.info("AWS SDK Version: " + AWS.VERSION);
 
 const awsDynamoDbEndpoint = "https://dynamodb." + process.env.AWS_REGION + ".amazonaws.com";

--- a/index.js
+++ b/index.js
@@ -43,10 +43,10 @@ client.on('ready', () => {
   PREFIX = "<@!" + client.user.id + ">";
 
   // ---------- Load Bot Config
+  client.commands.get('config').initializeConfig(client, logger);
   client.guilds.cache.forEach(function (server) {
     logger.info('Guild ID: ' + server.id);
     client.botConfig[server.id] = new DiscordCollection.Collection();
-    client.commands.get('config').initializeConfig(client, logger);
 
     // Check newArrivals every hour
     const interval = 1000 * 60 * 60; // 1 second * 60 = 1 minute * 60 = 1 hour

--- a/index.js
+++ b/index.js
@@ -2,8 +2,10 @@ require("dotenv").config();
 
 // ---------- Winston Logger Declarations
 const winston = require('winston');
+var log_level = process.env.LOG_LEVEL || 'info';
+
 const logger = winston.createLogger({
-  level: 'debug',
+  level: log_level,
   transports: [
     new winston.transports.Console({format: winston.format.combine(winston.format.colorize(), winston.format.simple())}),
     new winston.transports.File({filename: 'logs/combined.log'})

--- a/index.js
+++ b/index.js
@@ -10,25 +10,6 @@ const logger = winston.createLogger({
   ]
 });
 
-// ---------- sqlite Declarations
-var AWS = require("sqlite3").verbose();
-let db = new sqlite3.Database(process.env.DBFILE, (err) => {
-  if (err) {
-    console.error(err.message);
-  }
-  console.log('Connected to the database: ' & process.env.DBFILE);
-});
-
-
-logger.info("AWS SDK Version: " + AWS.VERSION);
-
-const awsDynamoDbEndpoint = "https://dynamodb." + process.env.AWS_REGION + ".amazonaws.com";
-logger.debug("Setting endpoint: " + awsDynamoDbEndpoint);
-
-AWS.config.update({endpoint: awsDynamoDbEndpoint, region: process.env.AWS_REGION});
-AWS.config.apiVersions = { dynamodb: '2012-08-10' };
-var docClient = new AWS.DynamoDB.DocumentClient();
-
 
 // ---------- Discord.js Declarations
 const { Client, Intents, Discord } = require("discord.js");
@@ -37,6 +18,15 @@ const client = new Client({ intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_
 client.commands = new DiscordCollection.Collection();
 client.botConfig = new DiscordCollection.Collection();
 
+// ---------- sqlite Declarations
+const sqlite3 = require("sqlite3").verbose();
+client.db = new sqlite3.Database(process.env.DBFILE, (err) => {
+  if (err) {
+    logger.error("Unable to connect to database: " + err);
+  }
+  logger.info('Connected to the database: ' & process.env.DBFILE);
+});
+
 // ---------- Load Commands
 const botCommands = require('./commands');
 Object.keys(botCommands).map(key => {
@@ -44,7 +34,7 @@ Object.keys(botCommands).map(key => {
 });
 
 // ---------- Start Bot
-const TOKEN = process.env.TOKEN;
+const TOKEN  = process.env.TOKEN;
 var   PREFIX = "";
 client.login(TOKEN);
 
@@ -52,15 +42,16 @@ client.on('ready', () => {
   logger.info(`Logged in as ${client.user.tag}!`);
   PREFIX = "<@!" + client.user.id + ">";
 
+  // ---------- Load Bot Config
   client.guilds.cache.forEach(function (server) {
     logger.info('Guild ID: ' + server.id);
     client.botConfig[server.id] = new DiscordCollection.Collection();
-    client.commands.get('config').getServerConfig(server.id, client, logger, docClient);
+    client.commands.get('config').initializeConfig(client, logger);
 
     // Check newArrivals every hour
     const interval = 1000 * 60 * 60; // 1 second * 60 = 1 minute * 60 = 1 hour
-    client.botConfig[server.id].newArrivalInterval = setInterval(client.commands.get('welcome_activity').checkNewArrivals, interval, server.id, client, logger, docClient);
-    client.commands.get('welcome_activity').checkNewArrivals(server.id, client, logger, docClient);
+    client.botConfig[server.id].newArrivalInterval = setInterval(client.commands.get('welcome_activity').checkNewArrivals, interval, server.id, client, logger);
+    client.commands.get('welcome_activity').checkNewArrivals(server.id, client, logger);
   });
   logger.info("Ready.");
 });
@@ -72,7 +63,7 @@ client.on('message', message => {
     logger.info(`Called command: ${command}`);
 
     if (command == "checknewarrivals") 
-      client.commands.get('welcome_activity').checkNewArrivals(message.guild.id, client, logger, docClient);
+      client.commands.get('welcome_activity').checkNewArrivals(message.guild.id, client, logger);
 
     // If the command doesn't exist, silently return
     if (!client.commands.has(command)) return;
@@ -85,12 +76,12 @@ client.on('message', message => {
 
   } else if ((message.channel.id == "752154612798062612") || (message.channel.id == "752462096104423536") 
            ||(message.channel.id == "704057794571272366")) {
-    client.commands.get('channel_activity').execute(message, logger, docClient);
+    client.commands.get('channel_activity').execute(message, logger);
   } else {
     logger.debug(message.content);
   }
 });
 
 client.on('guildMemberAdd', member => {
-  client.commands.get('welcome_activity').addMember(member, logger, docClient);
+  client.commands.get('welcome_activity').addMember(member, logger);
 });

--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ client.on('message', message => {
     }
 
   } else if ((message.channel.id == "752154612798062612") || (message.channel.id == "752462096104423536") 
-           ||(message.channel.id == "704057794571272366")) {
+           ||(message.channel.id == "740177216134053890")) {
     client.commands.get('channel_activity').execute(message, logger);
   } else {
     logger.debug(message.content);

--- a/lib/create-db.js
+++ b/lib/create-db.js
@@ -17,12 +17,7 @@ if (fs.existsSync(process.env.DBFILE)) {
   });
     
   db.serialize(() => {
-    db.run(`CREATE TABLE IF NOT EXISTS configTable (
-      configTableId INTEGER PRIMARY KEY
-    , serverId      TEXT
-    , configSetting TEXT
-    , configValue   TEXT)`)
-    .run(`CREATE TABLE IF NOT EXISTS joinTable ( 
+    db.run(`CREATE TABLE IF NOT EXISTS joinTable ( 
       joinTableId   INTEGER PRIMARY KEY
     , serverId      TEXT
     , memberId      TEXT
@@ -36,6 +31,7 @@ if (fs.existsSync(process.env.DBFILE)) {
     , memberId          TEXT
     , messageDateTime   INTEGER
     , messageLink       TEXT
-    , messageWordCount  TEXT)`);
+    , messageWordCount  TEXT
+    , userLastMessageDelta      INTEGER)`);
   });
 }

--- a/lib/create-db.js
+++ b/lib/create-db.js
@@ -9,31 +9,33 @@ if (fs.existsSync(process.env.DBFILE)) {
     console.log('Connected to the database.');
   });
 } else {
-  let db = new sqlite3.Database(process.env.DBFILE, sqlite3.OPEN_CREATE(err) => {
+  let db = new sqlite3.Database(process.env.DBFILE, (err) => {
     if (err) {
       console.error(err.message);
     }
     console.log('Connected to the database.');
-    db.serialize(() => {
-      db.run("CREATE TABLE IF NOT EXISTS configTable (
-        configTableId INTEGER PRIMARY KEY
-      , serverId      TEXT
-      , configSetting TEXT
-      , configValue   TEXT)")
-      .run("CREATE TABLE IF NOT EXISTS joinTable ( 
-        joinTableId   INTEGER PRIMARY KEY
-      , serverId      TEXT
-      , memberId      TEXT
-      , joinDateTime  INTEGER)"
-      .run("CREATE TABLE IF NOT EXISTS chatTable (
-        chatTableId       INTEGER PRIMARY KEY
-      , serverId          TEXT
-      , messageId         TEXT
-      , channelId         TEXT
-      , lastChannelMessageDelta   INTEGER
-      , memberId          TEXT
-      , messageDateTime   INTEGER
-      , messageLink       TEXT
-      , messageWordCount  TEXT)")
+  });
+    
+  db.serialize(() => {
+    db.run(`CREATE TABLE IF NOT EXISTS configTable (
+      configTableId INTEGER PRIMARY KEY
+    , serverId      TEXT
+    , configSetting TEXT
+    , configValue   TEXT)`)
+    .run(`CREATE TABLE IF NOT EXISTS joinTable ( 
+      joinTableId   INTEGER PRIMARY KEY
+    , serverId      TEXT
+    , memberId      TEXT
+    , joinDateTime  INTEGER)`)
+    .run(`CREATE TABLE IF NOT EXISTS chatTable (
+      chatTableId       INTEGER PRIMARY KEY
+    , serverId          TEXT
+    , messageId         TEXT
+    , channelId         TEXT
+    , lastChannelMessageDelta   INTEGER
+    , memberId          TEXT
+    , messageDateTime   INTEGER
+    , messageLink       TEXT
+    , messageWordCount  TEXT)`);
   });
 }

--- a/lib/create-db.js
+++ b/lib/create-db.js
@@ -1,0 +1,39 @@
+const fs = require('fs');
+const sqlite3 = require('sqlite3').verbose();
+
+if (fs.existsSync(process.env.DBFILE)) {
+  let db = new sqlite3.Database(process.env.DBFILE, sqlite3.OPEN_READONLY, (err) => {
+    if (err) {
+      console.error(err.message);
+    }
+    console.log('Connected to the database.');
+  });
+} else {
+  let db = new sqlite3.Database(process.env.DBFILE, sqlite3.OPEN_CREATE(err) => {
+    if (err) {
+      console.error(err.message);
+    }
+    console.log('Connected to the database.');
+    db.serialize(() => {
+      db.run("CREATE TABLE IF NOT EXISTS configTable (
+        configTableId INTEGER PRIMARY KEY
+      , serverId      TEXT
+      , configSetting TEXT
+      , configValue   TEXT)")
+      .run("CREATE TABLE IF NOT EXISTS joinTable ( 
+        joinTableId   INTEGER PRIMARY KEY
+      , serverId      TEXT
+      , memberId      TEXT
+      , joinDateTime  INTEGER)"
+      .run("CREATE TABLE IF NOT EXISTS chatTable (
+        chatTableId       INTEGER PRIMARY KEY
+      , serverId          TEXT
+      , messageId         TEXT
+      , channelId         TEXT
+      , lastChannelMessageDelta   INTEGER
+      , memberId          TEXT
+      , messageDateTime   INTEGER
+      , messageLink       TEXT
+      , messageWordCount  TEXT)")
+  });
+}

--- a/lib/database-schema.sql
+++ b/lib/database-schema.sql
@@ -19,4 +19,6 @@ CREATE TABLE IF NOT EXISTS chatTable (
   , memberId          TEXT
   , messageDateTime   INTEGER
   , messageLink       TEXT
-  , messageWordCount  TEXT);
+  , messageWordCount  TEXT
+  , userLastMessageDelta      INTEGER);
+  

--- a/lib/database-schema.sql
+++ b/lib/database-schema.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS configTable (
+    configTableId INTEGER PRIMARY KEY
+  , serverId      TEXT
+  , configSetting TEXT
+  , configValue   TEXT);
+
+CREATE TABLE IF NOT EXISTS joinTable ( 
+    joinTableId   INTEGER PRIMARY KEY
+  , serverId      TEXT
+  , memberId      TEXT
+  , joinDateTime  INTEGER);
+
+CREATE TABLE IF NOT EXISTS chatTable (
+    chatTableId       INTEGER PRIMARY KEY
+  , serverId          TEXT
+  , messageId         TEXT
+  , channelId         TEXT
+  , lastChannelMessageDelta   INTEGER
+  , memberId          TEXT
+  , messageDateTime   INTEGER
+  , messageLink       TEXT
+  , messageWordCount  TEXT);

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,11 @@
         "mime-types": "^2.1.12"
       }
     },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
     "abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -36,6 +41,81 @@
       "requires": {
         "event-target-shim": "^5.0.0"
       }
+    },
+    "ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "optional": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+    },
+    "are-we-there-yet": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
+      "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "optional": true,
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "optional": true
     },
     "async": {
       "version": "3.2.0",
@@ -63,10 +143,62 @@
         "xml2js": "0.4.19"
       }
     },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "optional": true
+    },
+    "aws4": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
+      "optional": true
+    },
+    "balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "optional": true,
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      },
+      "dependencies": {
+        "tweetnacl": {
+          "version": "0.14.5",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+          "optional": true
+        }
+      }
+    },
+    "block-stream": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+      "optional": true,
+      "requires": {
+        "inherits": "~2.0.0"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "buffer": {
       "version": "4.9.2",
@@ -77,6 +209,22 @@
         "ieee754": "^1.1.4",
         "isarray": "^1.0.0"
       }
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "optional": true
+    },
+    "chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "color": {
       "version": "3.0.0",
@@ -131,15 +279,57 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "optional": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
     },
     "discord.js": {
       "version": "12.5.3",
@@ -161,6 +351,16 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
       "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
     },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "optional": true,
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "enabled": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
@@ -175,6 +375,30 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "optional": true
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "optional": true
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "optional": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "optional": true
     },
     "fast-safe-stringify": {
       "version": "2.0.7",
@@ -191,35 +415,244 @@
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "optional": true
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "optional": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "fs-minipass": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+      "requires": {
+        "minipass": "^2.6.0"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "fstream": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "optional": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      }
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "requires": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      }
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "optional": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "glob": {
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
+      "optional": true
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "optional": true
+    },
+    "har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "optional": true,
+      "requires": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      }
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "optional": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
       "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+    },
+    "ignore-walk": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.4.tgz",
+      "integrity": "sha512-PY6Ii8o1jMRA1z4F2hRkH/xN59ox43DavKvD3oDpfurRlOJyAHpifIwpbdv1n4jt4ov0jSpw3kQ4GhJnpBL6WQ==",
+      "requires": {
+        "minimatch": "^3.0.4"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
     },
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
+    "ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+    },
     "is-arrayish": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
     },
     "is-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
       "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
     },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "optional": true
+    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "optional": true
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "optional": true
+    },
     "jmespath": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "optional": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "optional": true
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "optional": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "optional": true
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "optional": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
     },
     "kuler": {
       "version": "2.0.0",
@@ -251,15 +684,204 @@
         "mime-db": "1.47.0"
       }
     },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+    },
+    "minipass": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+      "requires": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      }
+    },
+    "minizlib": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+      "requires": {
+        "minipass": "^2.9.0"
+      }
+    },
+    "mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
     "ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
+    "needle": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.9.1.tgz",
+      "integrity": "sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==",
+      "requires": {
+        "debug": "^3.2.6",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      },
+      "dependencies": {
+        "sax": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+        }
+      }
+    },
+    "node-addon-api": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="
+    },
     "node-fetch": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
       "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+    },
+    "node-gyp": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
+      "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
+      "optional": true,
+      "requires": {
+        "fstream": "^1.0.0",
+        "glob": "^7.0.3",
+        "graceful-fs": "^4.1.2",
+        "mkdirp": "^0.5.0",
+        "nopt": "2 || 3",
+        "npmlog": "0 || 1 || 2 || 3 || 4",
+        "osenv": "0",
+        "request": "^2.87.0",
+        "rimraf": "2",
+        "semver": "~5.3.0",
+        "tar": "^2.0.0",
+        "which": "1"
+      }
+    },
+    "node-pre-gyp": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.11.0.tgz",
+      "integrity": "sha512-TwWAOZb0j7e9eGaf9esRx3ZcLaE5tQ2lvYy1pb5IAaG1a2e2Kv5Lms1Y4hpj+ciXJRofIxxlt5haeQ/2ANeE0Q==",
+      "requires": {
+        "detect-libc": "^1.0.2",
+        "mkdirp": "^0.5.1",
+        "needle": "^2.2.1",
+        "nopt": "^4.0.1",
+        "npm-packlist": "^1.1.6",
+        "npmlog": "^4.0.2",
+        "rc": "^1.2.7",
+        "rimraf": "^2.6.1",
+        "semver": "^5.3.0",
+        "tar": "^4"
+      },
+      "dependencies": {
+        "nopt": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
+          "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        },
+        "tar": {
+          "version": "4.4.19",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
+          "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
+          "requires": {
+            "chownr": "^1.1.4",
+            "fs-minipass": "^1.2.7",
+            "minipass": "^2.9.0",
+            "minizlib": "^1.3.3",
+            "mkdirp": "^0.5.5",
+            "safe-buffer": "^5.2.1",
+            "yallist": "^3.1.1"
+          }
+        }
+      }
+    },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "optional": true,
+      "requires": {
+        "abbrev": "1"
+      }
+    },
+    "npm-bundled": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.2.tgz",
+      "integrity": "sha512-x5DHup0SuyQcmL3s7Rx/YQ8sbw/Hzg0rj48eN0dV7hf5cmQq5PXIeioroH3raV1QC1yh3uTYuMThvEQF3iKgGQ==",
+      "requires": {
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
+    "npm-normalize-package-bin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA=="
+    },
+    "npm-packlist": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
+      "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
+      "requires": {
+        "ignore-walk": "^3.0.1",
+        "npm-bundled": "^1.0.1",
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "requires": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "optional": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
     },
     "one-time": {
       "version": "1.0.0",
@@ -268,6 +890,36 @@
       "requires": {
         "fn.name": "1.x.x"
       }
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "optional": true
     },
     "prism-media": {
       "version": "1.2.9",
@@ -279,15 +931,38 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
+    "psl": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+      "optional": true
+    },
     "punycode": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
       "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
     },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "optional": true
+    },
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      }
     },
     "readable-stream": {
       "version": "3.6.0",
@@ -299,20 +974,76 @@
         "util-deprecate": "^1.0.1"
       }
     },
+    "request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "optional": true,
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      }
+    },
+    "rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sax": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
       "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
+    "semver": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
     "setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+    },
+    "signal-exit": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
     "simple-swizzle": {
       "version": "0.2.2",
@@ -322,10 +1053,55 @@
         "is-arrayish": "^0.3.1"
       }
     },
+    "sqlite3": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.0.2.tgz",
+      "integrity": "sha512-1SdTNo+BVU211Xj1csWa8lV6KM0CtucDwRyA0VHl91wEH1Mgh7RxUpI4rVvG7OhHrzCSGaVyW5g8vKvlrk9DJA==",
+      "requires": {
+        "node-addon-api": "^3.0.0",
+        "node-gyp": "3.x",
+        "node-pre-gyp": "^0.11.0"
+      }
+    },
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "optional": true,
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "dependencies": {
+        "tweetnacl": {
+          "version": "0.14.5",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+          "optional": true
+        }
+      }
+    },
     "stack-trace": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "requires": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      }
     },
     "string_decoder": {
       "version": "1.3.0",
@@ -335,20 +1111,88 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+    },
+    "tar": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
+      "optional": true,
+      "requires": {
+        "block-stream": "*",
+        "fstream": "^1.0.12",
+        "inherits": "2"
+      }
+    },
     "text-hex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
       "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+    },
+    "tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "optional": true,
+      "requires": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+          "optional": true
+        }
+      }
     },
     "triple-beam": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
       "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "optional": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "tweetnacl": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
       "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+    },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "optional": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+          "optional": true
+        }
+      }
     },
     "url": {
       "version": "0.10.3",
@@ -368,6 +1212,34 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "optional": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "optional": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      }
     },
     "winston": {
       "version": "3.3.3",
@@ -423,6 +1295,11 @@
         }
       }
     },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
     "ws": {
       "version": "7.4.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
@@ -441,6 +1318,11 @@
       "version": "9.0.7",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+    },
+    "yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "aws-sdk": "^2.884.0",
     "discord.js": "^12.5.3",
     "dotenv": "^8.2.0",
+    "sqlite3": "^5.0.2",
     "winston": "^3.3.3"
   },
   "devDependencies": {},


### PR DESCRIPTION
This is a feature-parity release of v1.2 that I see was never formally released.  The main reason to move to sqlite as the database is because DyanmoDB was more expensive than I anticipated.  While the storage and engine was free, the autoscaling and monitoring were not.

DyanmoDB was an over-engineered solution anyway.  If you'd like to keep this feature, please let me know in the actions.

This should be a #major release since it is not backwards compatible.